### PR TITLE
Add declaration-block-trailing-semicolon as disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
 	},
 	"stylelint": {
 		"extends": "stylelint-config-xo",
-		"rules": {}
+		"rules": {
+			"declaration-block-trailing-semicolon": ["never"]
+		}
 	}
 }


### PR DESCRIPTION
**What changed**
- Disabled [`declaration-block-trailing-semicolon`](https://stylelint.io/user-guide/rules/declaration-block-trailing-semicolon/) rule to match the js code style